### PR TITLE
Added "limit=3" to paginated_list in the final code

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -198,7 +198,7 @@ For reference, the final code for the tutorial is::
     @auto_service
     class PostsService(Service):
         list = hvild.list(Post)
-        paginated_list = hvild.paginated_list(Post)
+        paginated_list = hvild.paginated_list(Post, limit=3)
         get = hvild.get(Post)
         delete = hvild.delete(Post)
         insert = hvild.insert(Post)


### PR DESCRIPTION
The final code doesn't reflect the limit parameter thus when testing `ferris.post.paginated_list` in Google API Explorer, behaviour is the same as `ferris.post.list`
Changed from 
`paginated_list = hvild.paginated_list(Post)`
to
`paginated_list = hvild.paginated_list(Post, limit=3)`
